### PR TITLE
sock.Accept should return new socket as well!

### DIFF
--- a/_socket.ahk
+++ b/_socket.ahk
@@ -220,7 +220,7 @@ class winsock {
         return retCode
     }
     
-    Accept(&addr:=0) { ; optional VarRef to capture the sockaddr struct of new connection
+    Accept(&addr:=0,&newsock:=0) { ; optional VarRef to capture the sockaddr struct of new connection
         retCode := 1
         buf := buffer(16,0)
         NumPut("UInt",16,sz := buffer(4,0))


### PR DESCRIPTION
The server doesn't just require the address, it may require the newsocket object as well, since the server might need to send messages to the client!